### PR TITLE
[proj] fixed array size overflow; added requesting allocation size when OOM happens

### DIFF
--- a/gunrock/app/proj/proj_problem.cuh
+++ b/gunrock/app/proj/proj_problem.cuh
@@ -64,7 +64,7 @@ struct Problem : ProblemBase<_GraphT, _FLAG>
     struct DataSlice : BaseDataSlice
     {
 
-        util::Array1D<SizeT, ValueT> projections;
+        util::Array1D<uint64_t, ValueT> projections;
 
         /*
          * @brief Default constructor
@@ -115,7 +115,7 @@ struct Problem : ProblemBase<_GraphT, _FLAG>
 
             GUARD_CU(BaseDataSlice::Init(sub_graph, num_gpus, gpu_idx, target, flag));
 
-            GUARD_CU(projections.Allocate(sub_graph.nodes * sub_graph.nodes, target));
+            GUARD_CU(projections.Allocate((uint64_t)sub_graph.nodes * sub_graph.nodes, target));
 
             if (target & util::DEVICE) {
                 GUARD_CU(sub_graph.CsrT::Move(util::HOST, target, this -> stream));

--- a/gunrock/util/array_utils.cuh
+++ b/gunrock/util/array_utils.cuh
@@ -472,7 +472,8 @@ public:
             if (size!=0) {
                 retval = GRError(
                     cudaMalloc((void**)&(d_pointer), sizeof(ValueT) * size),
-                    std::string(name) + " cudaMalloc failed", __FILE__, __LINE__);
+                    std::string(name) + " cudaMalloc failed when allocating "
+                    + std::to_string(sizeof(ValueT) * size) + " bytes", __FILE__, __LINE__);
                 if (retval) return retval;
             }
             allocated = allocated | DEVICE;


### PR DESCRIPTION
Now it fails nicer
```
sgpyc@mario:~/Projects/gunrock_master/tests/proj$ ./bin/test_proj_9.2_x86_64 market /data/gunrock_dataset/large/hollywood-2009/hollywood-2009.mtx --quick
Loading Matrix-market coordinate-formatted graph ...
Reading from /data/gunrock_dataset/large/hollywood-2009/hollywood-2009.mtx:
  Parsing MARKET COO format edge-value-seed = 1539192848
 (1139905 nodes, 115031232 directed edges)...
Done parsing (19 s).
Removed 2279810 duplicate edges and self circles.
  Converting 1139905 vertices, 112751422 directed edges ( ordered tuples) to CSR format...
Done converting (0s).
==============================================
 advance-mode=LB
[../../gunrock/util/array_utils.cuh, 476 @ gpu 0] projections cudaMalloc failed when allocating 5197533636100 bytes (CUDA error 2: out of memory)
[../../gunrock/app/proj/proj_problem.cuh, 118 @ gpu 0] error encountered (CUDA error 2: out of memory)
[../../gunrock/app/proj/proj_problem.cuh, 292 @ gpu 0] error encountered (CUDA error 2: out of memory)
[../../gunrock/app/proj/proj_app.cu, 78 @ gpu 0] error encountered (CUDA error 2: out of memory)
[test_proj.cu, 88 @ gpu 0] error encountered (CUDA error 2: out of memory)
```